### PR TITLE
Implement encode

### DIFF
--- a/cmd/bech32/go.mod
+++ b/cmd/bech32/go.mod
@@ -13,3 +13,5 @@ require (
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 )
+
+replace "github.com/savaki/bech32" => "../../"

--- a/cmd/bech32/go.sum
+++ b/cmd/bech32/go.sum
@@ -1,0 +1,15 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/icza/bitio v1.0.0 h1:squ/m1SHyFeCA6+6Gyol1AxV9nmPPlJFT8c2vKdj3U8=
+github.com/icza/bitio v1.0.0/go.mod h1:0jGnlLAx8MKMr9VGnn/4YrvZiprkvBelsVIbA9Jjr9A=
+github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6/go.mod h1:xQig96I1VNBDIWGCdTt54nHt6EeI639SmHycLYL7FkA=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
+github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/cmd/bech32/main.go
+++ b/cmd/bech32/main.go
@@ -12,10 +12,25 @@ import (
 
 var opts struct {
 	Format string
+	HRP    string
 }
 
 func main() {
 	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		{
+			Name:    "decode",
+			Aliases: []string{"d"},
+			Usage:   "decode a bech32 string to a human readable part and hex encoded data",
+			Action:  decode,
+		},
+		{
+			Name:    "encode",
+			Aliases: []string{"e"},
+			Usage:   "encode a human readable part and hex encoded data to bech32",
+			Action:  encode,
+		},
+	}
 	app.Usage = "parse bech32 encoded string"
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
@@ -25,7 +40,7 @@ func main() {
 			Destination: &opts.Format,
 		},
 	}
-	app.Action = action
+	app.Action = infer
 	err := app.Run(os.Args)
 	if err != nil {
 		fmt.Println(err)
@@ -33,7 +48,17 @@ func main() {
 	}
 }
 
-func action(c *cli.Context) error {
+func infer(c *cli.Context) error {
+	first := c.Args().First()
+	_, _, err := bech32.Decode(first)
+	if err != nil {
+		return encode(c)
+	} else {
+		return decode(c)
+	}
+}
+
+func decode(c *cli.Context) error {
 	var records []interface{}
 	for _, addr := range c.Args().Slice() {
 		hrp, data, err := bech32.Decode(addr)
@@ -51,6 +76,44 @@ func action(c *cli.Context) error {
 			})
 		default:
 			fmt.Printf("%v: %v %v\n", addr, hrp, hex.EncodeToString(data))
+		}
+	}
+
+	switch opts.Format {
+	case "json":
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(records)
+	default:
+		return nil
+	}
+}
+
+func encode(c *cli.Context) error {
+	var records []interface{}
+	args := c.Args().Slice()
+	for i := 0; i < len(args); i += 2 {
+		hrp := args[i]
+		data, err := hex.DecodeString(args[i+1])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "bech32: failed to encode data, %v: %v", data, err)
+			os.Exit(1)
+		}
+		addr, err := bech32.Encode(hrp, data)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "bech32: failed to encode data, %v: %v", data, err)
+			os.Exit(1)
+		}
+
+		switch opts.Format {
+		case "json":
+			records = append(records, map[string]interface{}{
+				"hrp":  hrp,
+				"data": hex.EncodeToString(data),
+				"addr": addr,
+			})
+		default:
+			fmt.Printf("%v %v: %v\n", hrp, hex.EncodeToString(data), addr)
 		}
 	}
 

--- a/decode.go
+++ b/decode.go
@@ -32,25 +32,6 @@ import (
 	"github.com/icza/bitio"
 )
 
-var (
-	ErrInvalidCharacter = errors.New("invalid character")
-	ErrInvalidFormat    = errors.New("invalid format")
-	ErrInvalidLength    = errors.New("invalid length")
-)
-
-const (
-	sep = "1"
-)
-
-var charset = []int{
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	15, -1, 10, 17, 21, 20, 26, 30, 7, 5, -1, -1, -1, -1, -1, -1, -1, 29, -1, 24, 13, 25, 9, 8, 23,
-	-1, 18, 22, 31, 27, 19, -1, 1, 0, 3, 16, 11, 28, 12, 14, 6, 4, 2, -1, -1, -1, -1, -1, -1, 29,
-	-1, 24, 13, 25, 9, 8, 23, -1, 18, 22, 31, 27, 19, -1, 1, 0, 3, 16, 11, 28, 12, 14, 6, 4, 2, -1,
-	-1, -1, -1, -1,
-}
-
 // Decode bech32 string into its human-readable part (hrp) and its associated data
 func Decode(addr string) (hrp string, data []byte, err error) {
 	if len(addr) < 8 {
@@ -72,11 +53,11 @@ func Decode(addr string) (hrp string, data []byte, err error) {
 	w := bitio.NewWriter(buf)
 	for _, r := range addr[index+1 : len(addr)-6] {
 		i := int(r)
-		if i >= len(charset) {
+		if i >= len(charset_rev) {
 			return "", nil, ErrInvalidCharacter
 		}
 
-		numValue := charset[i]
+		numValue := charset_rev[i]
 		if numValue > 31 || numValue < 0 {
 			return "", nil, ErrInvalidCharacter
 		}

--- a/encode.go
+++ b/encode.go
@@ -1,0 +1,72 @@
+package bech32
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/icza/bitio"
+)
+
+func polymodStep(v byte, chk int) int {
+	b := byte(chk >> 25)
+	chk = (chk&0x01ff_ffff)<<5 ^ int(v)
+	for i, g := range gen {
+		if (b>>i)&1 == 1 {
+			chk ^= g
+		}
+	}
+	return chk
+}
+
+// Encode a human readable part (hrp) and bytes as a bech32 string
+func Encode(hrp string, data []byte) (encoded string, err error) {
+	if len(hrp) < 1 {
+		return "", ErrInvalidLength
+	}
+
+	hrpBytes := []byte(hrp)
+	chk := 1
+
+	encoded = fmt.Sprintf("%s%s", hrp, sep)
+	for _, v := range hrpBytes {
+		chk = polymodStep(v>>5, chk)
+	}
+	chk = polymodStep(0, chk)
+	for _, v := range hrpBytes {
+		chk = polymodStep(v&0x1f, chk)
+	}
+
+	r := bitio.NewReader(bytes.NewBuffer(data))
+	for {
+		b, err := r.ReadBits(5)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				fmt.Printf("Aborting %v\n", b)
+				break
+			}
+			return "", ErrInvalidCharacter
+		}
+		chk = polymodStep(byte(b), chk)
+		fmt.Printf("%v: %v (%v)\n", b, charset[b], string(charset[b]))
+		encoded += string(charset[b])
+	}
+	fmt.Printf("%v\n", encoded)
+
+	for i := 0; i < 6; i++ {
+		chk = polymodStep(0, chk)
+	}
+
+	plm := chk ^ 1
+
+	checksum := []byte{}
+	for p := 0; p < 6; p++ {
+		c := (plm >> (5 * (5 - p))) & 0x1f
+		fmt.Printf("%v: %v (%v)\n", byte(c), charset[c], string(charset[c]))
+		checksum = append(checksum, charset[byte(c)])
+	}
+	encoded += string(checksum)
+	fmt.Printf("%s", encoded)
+	return encoded, nil
+}

--- a/encode.go
+++ b/encode.go
@@ -1,3 +1,25 @@
+// MIT License
+//
+// Copyright (c) 2021 Matt Ho
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package bech32
 
 import (

--- a/encode_test.go
+++ b/encode_test.go
@@ -1,0 +1,111 @@
+// MIT License
+//
+// Copyright (c) 2021 Matt Ho
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package bech32
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestEncode(t *testing.T) {
+	testCases := map[string]struct {
+		HRP     string
+		Data    string
+		Want    string
+		WantErr bool
+	}{
+		"blank": {
+			WantErr: true,
+		},
+		"type-00": {
+			HRP:  "addr",
+			Data: "019493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251",
+			Want: "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x",
+		},
+		/*"type-01": {
+			HRP:  "addr",
+			Data: "11c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251",
+			Want: "addr1z8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs9yc0hh",
+		},
+		"type-02": {
+			HRP:  "addr",
+			Data: "219493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8ec37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f",
+			Want: "addr1yx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerkr0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shs2z78ve",
+		},
+		"type-03": {
+			HRP:  "addr",
+			Data: "31c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542fc37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f",
+			Want: "addr1x8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gt7r0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shskhj42g",
+		},
+		"type-04": {
+			HRP:  "addr",
+			Data: "419493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e8198bd431b03",
+			Want: "addr1gx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5pnz75xxcrzqf96k",
+		},
+		"type-05": {
+			HRP:  "addr",
+			Data: "51c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f8198bd431b03",
+			Want: "addr128phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtupnz75xxcrtw79hu",
+		},
+		"type-06": {
+			HRP:  "addr",
+			Data: "619493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e",
+			Want: "addr1vx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers66hrl8",
+		},
+		"type-07": {
+			HRP:  "addr",
+			Data: "71c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f",
+			Want: "addr1w8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcyjy7wx",
+		},
+		"type-08": {
+			HRP:  "stake",
+			Data: "e1337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251",
+			Want: "stake1uyehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gh6ffgw",
+		},
+		"type-09": {
+			HRP:  "stake",
+			Data: "f1c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f",
+			Want: "stake178phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcccycj5",
+		},*/
+	}
+
+	for label, tc := range testCases {
+		t.Run(label, func(t *testing.T) {
+			bytes, _ := hex.DecodeString(tc.Data)
+			got, err := Encode(tc.HRP, bytes)
+			if tc.WantErr {
+				if err == nil {
+					t.Fatalf("expected not nil, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("got %v; want nil", err)
+			}
+			if want := tc.Want; got != want {
+				t.Fatalf("got %v; want %v", got, want)
+			}
+		})
+	}
+}

--- a/encode_test.go
+++ b/encode_test.go
@@ -42,7 +42,7 @@ func TestEncode(t *testing.T) {
 			Data: "019493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251",
 			Want: "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x",
 		},
-		/*"type-01": {
+		"type-01": {
 			HRP:  "addr",
 			Data: "11c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251",
 			Want: "addr1z8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs9yc0hh",
@@ -86,7 +86,7 @@ func TestEncode(t *testing.T) {
 			HRP:  "stake",
 			Data: "f1c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f",
 			Want: "stake178phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcccycj5",
-		},*/
+		},
 	}
 
 	for label, tc := range testCases {

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+github.com/icza/bitio v1.0.0 h1:squ/m1SHyFeCA6+6Gyol1AxV9nmPPlJFT8c2vKdj3U8=
+github.com/icza/bitio v1.0.0/go.mod h1:0jGnlLAx8MKMr9VGnn/4YrvZiprkvBelsVIbA9Jjr9A=
+github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6/go.mod h1:xQig96I1VNBDIWGCdTt54nHt6EeI639SmHycLYL7FkA=

--- a/shared.go
+++ b/shared.go
@@ -1,0 +1,32 @@
+package bech32
+
+import "errors"
+
+var (
+	ErrInvalidCharacter = errors.New("invalid character")
+	ErrInvalidFormat    = errors.New("invalid format")
+	ErrInvalidLength    = errors.New("invalid length")
+	ErrInvalidData      = errors.New("invalid data")
+)
+
+const (
+	sep = "1"
+)
+
+var charset_rev = []int{
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	15, -1, 10, 17, 21, 20, 26, 30, 7, 5, -1, -1, -1, -1, -1, -1, -1, 29, -1, 24, 13, 25, 9, 8, 23,
+	-1, 18, 22, 31, 27, 19, -1, 1, 0, 3, 16, 11, 28, 12, 14, 6, 4, 2, -1, -1, -1, -1, -1, -1, 29,
+	-1, 24, 13, 25, 9, 8, 23, -1, 18, 22, 31, 27, 19, -1, 1, 0, 3, 16, 11, 28, 12, 14, 6, 4, 2, -1,
+	-1, -1, -1, -1,
+}
+
+var charset = []byte{
+	'q', 'p', 'z', 'r', 'y', '9', 'x', '8',
+	'g', 'f', '2', 't', 'v', 'd', 'w', '0',
+	's', '3', 'j', 'n', '5', '4', 'k', 'h',
+	'c', 'e', '6', 'm', 'u', 'a', '7', 'l',
+}
+
+var gen = []int{0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3}


### PR DESCRIPTION
This is currently buggy; I can't figure out the checksum to correctly encode any of the test cases.

For example, something that should encode as:
```
addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x
```
instead encodes as
```
addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgug0jhp
```

Notably they are mostly equal, up to the checksum; I suspect the EOF happens when we still have exactly 5 bits left to read;

If I hard code an extra `s` (and polymod step) at the end of reading the buffer, it works fine for this test case.

Could use some help figuring this out